### PR TITLE
Update Vercel Node runtime to 20.x

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/**/*.ts": {
-      "runtime": "nodejs18.x"
+      "runtime": "nodejs20.x"
     }
   },
   "crons": [


### PR DESCRIPTION
## Summary
- update the Vercel serverless function runtime to the supported Node.js 20 runtime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dfd08ba4148325832f4c9ddb1221b2