### PR TITLE
Use supported Vercel Node builder

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/**/*.ts": {
-      "runtime": "nodejs18.x"
+      "runtime": "@vercel/node@2.15.10"
     }
   },
   "crons": [


### PR DESCRIPTION
## Summary
- switch serverless function runtime configuration to the explicit @vercel/node builder version required by Vercel

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dfd08ba4148325832f4c9ddb1221b2